### PR TITLE
Fix importing python-egnyte as a module/library

### DIFF
--- a/egnyte/__init__.py
+++ b/egnyte/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ['EgnyteClient']
 
-from egnyte.client import EgnyteClient
+from .client import EgnyteClient

--- a/egnyte/__init__.py
+++ b/egnyte/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ['EgnyteClient']
 
-from client import EgnyteClient
+from egnyte.client import EgnyteClient


### PR DESCRIPTION
This change fixes importing python-egnyte via an outside module by being more specific about where the 'client' module must be imported from.