### PR TITLE
Audit Report Bug Fixes

### DIFF
--- a/egnyte/audits.py
+++ b/egnyte/audits.py
@@ -128,3 +128,7 @@ class AuditReport(base.Resource):
     def json(self):
         r = self._client.GET(self.complete_url())
         return exc.default.check_json_response(r)
+
+    def delete(self):
+        r = self._client.DELETE(self.complete_url())
+        exc.default.check_response(r)

--- a/egnyte/exc.py
+++ b/egnyte/exc.py
@@ -127,7 +127,7 @@ class ErrorMapping(dict):
     """Maps HTTP status to EgnyteError subclasses"""
     ignored_errors = ()
 
-    def __init__(self, values=None, ok_statuses=(http_client.OK, ), ignored_errors=None):
+    def __init__(self, values=None, ok_statuses=(http_client.OK, http_client.NO_CONTENT), ignored_errors=None):
         super(ErrorMapping, self).__init__({
             http_client.BAD_REQUEST: RequestError,
             http_client.UNAUTHORIZED: NotAuthorized,


### PR DESCRIPTION
Could not delete audit reports via the python SDK for two reasons:

1) AuditReport class used the default Resource delete function. In the AuditReport class, this causes the 'job' endpoint to be used rather than the 'login'/'file'/etc endpoint with the complete url.
2) When an audit report is deleted it returns a 204 HTTP status. Currently the check_response function only accepts a 200 code and hence was throwing an exception.

I have implemented fixes to both functions. Would advise a wider catch on HTTP status codes to include all 2XX codes.