### PR TITLE
Revamped egnyte.resources.Search to use v2 API

### DIFF
--- a/egnyte/base.py
+++ b/egnyte/base.py
@@ -118,6 +118,7 @@ class HasClient(object):
 
     def __init__(self, _client, **kwargs):
         self._client = _client
+        self._raw_data = kwargs
         self.__dict__.update(kwargs)
 
 
@@ -239,6 +240,21 @@ def date_format(date):
     else:
         return date
 
+def date_in_ms(date):
+    if isinstance(date, (datetime.datetime, datetime.date)):
+        return int(date.strftime("%s")) * 1000
+    elif isinstance(date, (text_type, string_types)):
+        try:
+            date = datetime.datetime.strptime(date, "%Y-%m-%dT%H:%M:%S")
+            return int(date.strftime("%s")) * 1000 
+        except ValueError:
+            raise exc.InvalidParameters(
+                "Datetime string must be in ISO 8601 format. E.g YYYY-MM-DDTHH:MM:SS, " 
+                "the given date {%s} couldn't be parsed" % date
+            )
+    else:
+        return date
+
 
 def encode_path(path):
     if isinstance(path, text_type):
@@ -355,7 +371,8 @@ class ResultList(list):
     """
     # TODO: make this more lazy?
 
-    def __init__(self, data, total_count, offset):
+    def __init__(self, data, total_count, offset, has_more):
         super(ResultList, self).__init__(data)
         self.total_count = total_count
         self.offset = offset
+        self.has_more = has_more


### PR DESCRIPTION
`egnyte.resources.Search` had an issue with date filtering. That is, the Search v1 endpoint expects the date to be in ISO 8601 format with HH:MM:SS and timezone included (i.e. YYYY-MM-DDTHH:MM:SSZ). However, the `egnyte.resources.Search.files` was implemented to send only YYYY-MM-DD which resulted in "400 Bad Request" error. Besides, the existing method did not support custom metadata search and it only returned files and ignored the folders from the search results.

I have revamped the `Search` class to use v2 API which also supports custom metadata search and also returns folders in `ResultList`. When calling the `file` method of the `SearchMatch` objects in the `ResultList`, one can choose to discard the folders by passing `include_folders=False` as an argument to `SearchMatch.file` method. The `ResultList` was also updated to return the `has_more` attribute which the existing code did not return.