### PR TITLE
cmd_test bug fix

### DIFF
--- a/egnyte/__main__.py
+++ b/egnyte/__main__.py
@@ -239,7 +239,7 @@ class Commands(object):
 
     def cmd_test(self):
         api = self.get_client()
-        info = api.user_info()
+        info = api.user_info
         print("Connection successful for user %s" % (info['username'],))
 
     def cmd_search(self):


### PR DESCRIPTION
cmd_test yields the following error when running cli command "python -m egnyte test" (in Windows and Unix):
TypeError: 'dict' object is not callable

removing the function call '()', resolves the issue.